### PR TITLE
chore(eslint): promote no-explicit-any to error + #69 review fixes

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,8 @@ import globals from 'globals';
 
 export default [
     {
-        // Only lint src TS files (mirrors legacy .eslintignore behavior).
+        // Mirrors legacy .eslintignore behavior. scripts/css-to-ts.js is
+        // linted via the dedicated `files` block below.
         ignores: [
             'node_modules/**',
             'dist/**',
@@ -14,7 +15,10 @@ export default [
             'src/_libs/**',
             '**/*.spec.ts',
             '**/*.css.ts',
-            'scripts/**',
+            'scripts/create-new-tool.js',
+            'scripts/render-to-html.js',
+            'scripts/ssr-cli.js',
+            'scripts/validate-tools.js',
             'demo/**',
             'postbuild.js',
             'jest.config.ts',
@@ -52,7 +56,7 @@ export default [
                     varsIgnorePattern: '^_'
                 }
             ],
-            '@typescript-eslint/no-explicit-any': 'warn',
+            '@typescript-eslint/no-explicit-any': 'error',
             '@typescript-eslint/no-floating-promises': 'error',
             '@typescript-eslint/no-misused-promises': 'error',
             '@typescript-eslint/consistent-type-definitions': ['error', 'interface'],
@@ -134,6 +138,17 @@ export default [
                     ]
                 }
             ]
+        }
+    },
+    {
+        // Lint the css-to-ts build helper (was explicitly linted in the
+        // legacy setup and is still in the lint-staged glob).
+        files: ['scripts/css-to-ts.js'],
+        languageOptions: {
+            sourceType: 'module',
+            globals: {
+                ...globals.node
+            }
         }
     }
 ];

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "homepage": "https://github.com/Tooloogle/tools#readme",
   "engines": {
-    "node": ">=18"
+    "node": ">=18.18.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/src/age-calculator/age-calculator.spec.ts
+++ b/src/age-calculator/age-calculator.spec.ts
@@ -65,7 +65,7 @@ describe('age-calculator web component test', () => {
         component.today = '2000-01-02';
         component.calculate();
 
-        expect(component.result.total.days).toBe(1);
+        expect(component.result.total?.days).toBe(1);
     });
 
     it('should handle same date correctly', () => {

--- a/src/age-calculator/age-calculator.ts
+++ b/src/age-calculator/age-calculator.ts
@@ -13,7 +13,8 @@ dayjs.extend(duration);
 @customElement('age-calculator')
 export class AgeCalculator extends WebComponentBase {
   static override styles = [
-    WebComponentBase.styles,    ageCalculatorStyles];
+    WebComponentBase.styles,
+    ageCalculatorStyles];
 
   @property()
   haveTime = false;
@@ -25,7 +26,16 @@ export class AgeCalculator extends WebComponentBase {
   dob = '';
 
   @property()
-  result: any = {};
+  result: Partial<{
+    days: number;
+    months: number;
+    years: number;
+    hours: number;
+    minutes: number;
+    seconds: number;
+    milliseconds: number;
+    total: Record<string, number | string>;
+  }> = {};
 
   calculate() {
     // TODO: fix the date diff either in dayjs or use another lib or write our own code to calculate date diff
@@ -114,7 +124,7 @@ export class AgeCalculator extends WebComponentBase {
                 <table class="w-full table table-auto border-collapse">
                   <tbody>
                     ${repeat(
-                      Object.keys(this.result.total),
+                      Object.keys(this.result.total ?? {}),
                       key => html`
                         <tr
                           class="border-0 border-t border-solid dark:border-gray-700"
@@ -123,7 +133,7 @@ export class AgeCalculator extends WebComponentBase {
                             ${key}
                           </td>
                           <td class="px-6 py-2 text-end">
-                            ${formatNumber(this.result.total[key], 0)}
+                            ${formatNumber(Number(this.result.total?.[key] ?? 0), 0)}
                           </td>
                         </tr>
                       `

--- a/src/age-difference-calculator/age-difference-calculator.ts
+++ b/src/age-difference-calculator/age-difference-calculator.ts
@@ -13,7 +13,8 @@ dayjs.extend(duration);
 @customElement('age-difference-calculator')
 export class AgeDifferenceCalculator extends WebComponentBase {
   static override styles = [
-    WebComponentBase.styles,    ageDifferenceCalculatorStyles];
+    WebComponentBase.styles,
+    ageDifferenceCalculatorStyles];
 
   @property()
   haveTime = false;
@@ -25,7 +26,16 @@ export class AgeDifferenceCalculator extends WebComponentBase {
   date2 = '';
 
   @property()
-  result: any = {};
+  result: Partial<{
+    days: number;
+    months: number;
+    years: number;
+    hours: number;
+    minutes: number;
+    seconds: number;
+    milliseconds: number;
+    total: Record<string, number | string>;
+  }> = {};
 
   calculate() {
     const firstDate = dayjs(this.date1);
@@ -94,7 +104,7 @@ export class AgeDifferenceCalculator extends WebComponentBase {
                 <table class="w-full table table-auto border-collapse">
                   <tbody>
                     ${repeat(
-                      Object.keys(this.result.total),
+                      Object.keys(this.result.total ?? {}),
                       key => html`
                         <tr
                           class="border-0 border-t border-solid dark:border-gray-700"
@@ -103,7 +113,7 @@ export class AgeDifferenceCalculator extends WebComponentBase {
                             ${key}
                           </td>
                           <td class="px-6 py-2 text-end">
-                            ${formatNumber(this.result.total[key], 0)}
+                            ${formatNumber(Number(this.result.total?.[key] ?? 0), 0)}
                           </td>
                         </tr>
                       `

--- a/src/csv-to-xml-converter/csv-to-xml-converter.ts
+++ b/src/csv-to-xml-converter/csv-to-xml-converter.ts
@@ -8,7 +8,8 @@ import '../t-copy-button/index.js';
 @customElement('csv-to-xml-converter')
 export class CsvToXmlConverter extends WebComponentBase {
   static override styles = [
-    WebComponentBase.styles,    csvToXmlConverterStyles];
+    WebComponentBase.styles,
+    csvToXmlConverterStyles];
 
   @property({ type: String }) inputText = '';
   @property({ type: String }) outputText = '';
@@ -37,7 +38,7 @@ export class CsvToXmlConverter extends WebComponentBase {
 
       let xml = '<?xml version="1.0" encoding="UTF-8"?>\n<root>\n';
 
-      result.data.forEach((row: any) => {
+      (result.data as Array<Record<string, unknown>>).forEach((row) => {
         xml += '  <row>\n';
         for (const key in row) {
           if (Object.prototype.hasOwnProperty.call(row, key)) {

--- a/src/dns-lookup/dns-lookup.ts
+++ b/src/dns-lookup/dns-lookup.ts
@@ -8,7 +8,7 @@ export class DnsLookup extends WebComponentBase {
 
     @property({ type: String }) domain = '';
     @property({ type: String }) recordType = 'A';
-    @property({ type: Array }) results: any[] = [];
+    @property({ type: Array }) results: Array<{ name: string; type: number; TTL: number; data: string }> = [];
     @property({ type: String }) error = '';
     @property({ type: Boolean }) loading = false;
 

--- a/src/htaccess-generator/htaccess-generator.ts
+++ b/src/htaccess-generator/htaccess-generator.ts
@@ -7,7 +7,8 @@ import '../t-copy-button/index.js';
 @customElement('htaccess-generator')
 export class HtaccessGenerator extends WebComponentBase {
   static override styles = [
-    WebComponentBase.styles,    htaccessGeneratorStyles];
+    WebComponentBase.styles,
+    htaccessGeneratorStyles];
 
   @property({ type: Boolean }) enableWwwRedirect = false;
   @property({ type: Boolean }) enableHttpsRedirect = false;
@@ -23,7 +24,7 @@ export class HtaccessGenerator extends WebComponentBase {
 
   private handleCheckbox(field: string) {
     return (e: Event) => {
-      (this as any)[field] = (e.target as HTMLInputElement).checked;
+      (this as unknown as Record<string, unknown>)[field] = (e.target as HTMLInputElement).checked;
       this.process();
     };
   }

--- a/src/meta-tags-generator/meta-tags-generator.ts
+++ b/src/meta-tags-generator/meta-tags-generator.ts
@@ -7,7 +7,8 @@ import '../t-copy-button/index.js';
 @customElement('meta-tags-generator')
 export class MetaTagsGenerator extends WebComponentBase {
   static override styles = [
-    WebComponentBase.styles,    metaTagsGeneratorStyles];
+    WebComponentBase.styles,
+    metaTagsGeneratorStyles];
 
   @property({ type: String }) override title = '';
   @property({ type: String }) description = '';
@@ -24,7 +25,7 @@ export class MetaTagsGenerator extends WebComponentBase {
 
   private handleInput(field: string) {
     return (e: Event) => {
-      (this as any)[field] = (
+      (this as unknown as Record<string, unknown>)[field] = (
         e.target as HTMLInputElement | HTMLTextAreaElement
       ).value;
       this.process();

--- a/src/open-graph-generator/open-graph-generator.ts
+++ b/src/open-graph-generator/open-graph-generator.ts
@@ -7,7 +7,8 @@ import '../t-copy-button/index.js';
 @customElement("open-graph-generator")
 export class OpenGraphGenerator extends WebComponentBase {
   static override styles = [
-    WebComponentBase.styles,    openGraphGeneratorStyles];
+    WebComponentBase.styles,
+    openGraphGeneratorStyles];
 
   @property({ type: String }) override title = "";
   @property({ type: String }) description = "";
@@ -24,7 +25,7 @@ export class OpenGraphGenerator extends WebComponentBase {
 
   private handleInput(field: string) {
     return (e: Event) => {
-      (this as any)[field] = (
+      (this as unknown as Record<string, unknown>)[field] = (
         e.target as HTMLInputElement | HTMLTextAreaElement
       ).value;
       this.process();

--- a/src/sql-to-json-converter/sql-to-json-converter.ts
+++ b/src/sql-to-json-converter/sql-to-json-converter.ts
@@ -7,7 +7,8 @@ import '../t-copy-button/index.js';
 @customElement('sql-to-json-converter')
 export class SqlToJsonConverter extends WebComponentBase {
   static override styles = [
-    WebComponentBase.styles,    sqlToJsonConverterStyles];
+    WebComponentBase.styles,
+    sqlToJsonConverterStyles];
 
   @property({ type: String }) inputText = '';
   @property({ type: String }) outputText = '';
@@ -71,8 +72,8 @@ export class SqlToJsonConverter extends WebComponentBase {
       .filter(h => h);
   }
 
-  private parseDataRows(lines: string[], headers: string[]): any[] {
-    const result: any[] = [];
+  private parseDataRows(lines: string[], headers: string[]): Array<Record<string, unknown>> {
+    const result: Array<Record<string, unknown>> = [];
 
     for (const line of lines) {
       const trimmedLine = line.trim();
@@ -86,7 +87,7 @@ export class SqlToJsonConverter extends WebComponentBase {
         continue;
       }
 
-      const obj: any = {};
+      const obj: Record<string, unknown> = {};
       headers.forEach((header, index) => {
         obj[header] = this.parseValue(values[index]);
       });
@@ -97,7 +98,7 @@ export class SqlToJsonConverter extends WebComponentBase {
     return result;
   }
 
-  private parseValue(value: any): any {
+  private parseValue(value: string): string | number | boolean | null {
     // Try to parse as number
     if (/^-?\d+(\.\d+)?$/.test(value)) {
       return parseFloat(value);

--- a/src/tsv-to-json-converter/tsv-to-json-converter.ts
+++ b/src/tsv-to-json-converter/tsv-to-json-converter.ts
@@ -7,7 +7,8 @@ import '../t-copy-button/index.js';
 @customElement('tsv-to-json-converter')
 export class TsvToJsonConverter extends WebComponentBase {
   static override styles = [
-    WebComponentBase.styles,    tsvToJsonConverterStyles];
+    WebComponentBase.styles,
+    tsvToJsonConverterStyles];
 
   @property({ type: String }) inputText = '';
   @property({ type: String }) outputText = '';
@@ -37,7 +38,7 @@ export class TsvToJsonConverter extends WebComponentBase {
       // Parse remaining lines as data
       const data = lines.slice(1).map(line => {
         const values = line.split('\t');
-        const obj: any = {};
+        const obj: Record<string, string> = {};
         headers.forEach((header, index) => {
           obj[header] = values[index] || '';
         });

--- a/src/xml-to-csv-converter/xml-to-csv-converter.ts
+++ b/src/xml-to-csv-converter/xml-to-csv-converter.ts
@@ -7,7 +7,8 @@ import '../t-copy-button/index.js';
 @customElement('xml-to-csv-converter')
 export class XmlToCsvConverter extends WebComponentBase {
   static override styles = [
-    WebComponentBase.styles,    xmlToCsvConverterStyles];
+    WebComponentBase.styles,
+    xmlToCsvConverterStyles];
 
   @property({ type: String }) inputText = '';
   @property({ type: String }) outputText = '';
@@ -17,7 +18,7 @@ export class XmlToCsvConverter extends WebComponentBase {
     this.process();
   }
 
-  private xmlToJson(xml: string): any[] {
+  private xmlToJson(xml: string): Array<Record<string, unknown>> {
     const parser = new DOMParser();
     const xmlDoc = parser.parseFromString(xml, 'text/xml');
 
@@ -25,12 +26,12 @@ export class XmlToCsvConverter extends WebComponentBase {
       throw new Error('Invalid XML');
     }
 
-    const parseNode = (node: Element): any => {
+    const parseNode = (node: Element): unknown => {
       if (node.children.length === 0) {
         return node.textContent || '';
       }
 
-      const obj: any = {};
+      const obj: Record<string, unknown> = {};
       Array.from(node.children).forEach(child => {
         const key = child.tagName;
         const value =
@@ -42,7 +43,7 @@ export class XmlToCsvConverter extends WebComponentBase {
     };
 
     const rows = Array.from(xmlDoc.documentElement.children);
-    return rows.map(row => parseNode(row));
+    return rows.map(row => parseNode(row) as Record<string, unknown>);
   }
 
   private process() {

--- a/src/xml-to-yaml-converter/xml-to-yaml-converter.ts
+++ b/src/xml-to-yaml-converter/xml-to-yaml-converter.ts
@@ -8,7 +8,8 @@ import '../t-copy-button/index.js';
 @customElement('xml-to-yaml-converter')
 export class XmlToYamlConverter extends WebComponentBase {
   static override styles = [
-    WebComponentBase.styles,    xmlToYamlConverterStyles];
+    WebComponentBase.styles,
+    xmlToYamlConverterStyles];
 
   @property({ type: String }) inputText = '';
   @property({ type: String }) outputText = '';
@@ -18,7 +19,7 @@ export class XmlToYamlConverter extends WebComponentBase {
     this.process();
   }
 
-  private xmlToJson(xml: string): any {
+  private xmlToJson(xml: string): unknown {
     const parser = new DOMParser();
     const xmlDoc = parser.parseFromString(xml, 'text/xml');
 
@@ -26,12 +27,12 @@ export class XmlToYamlConverter extends WebComponentBase {
       throw new Error('Invalid XML');
     }
 
-    const parseNode = (node: Element): any => {
+    const parseNode = (node: Element): unknown => {
       if (node.children.length === 0) {
         return node.textContent || '';
       }
 
-      const obj: any = {};
+      const obj: Record<string, unknown> = {};
       const children = Array.from(node.children);
 
       children.forEach(child => {
@@ -43,7 +44,7 @@ export class XmlToYamlConverter extends WebComponentBase {
             obj[key] = [obj[key]];
           }
 
-          obj[key].push(value);
+          (obj[key] as unknown[]).push(value);
         } else {
           obj[key] = value;
         }

--- a/src/yaml-to-xml-converter/yaml-to-xml-converter.ts
+++ b/src/yaml-to-xml-converter/yaml-to-xml-converter.ts
@@ -8,7 +8,8 @@ import '../t-copy-button/index.js';
 @customElement('yaml-to-xml-converter')
 export class YamlToXmlConverter extends WebComponentBase {
   static override styles = [
-    WebComponentBase.styles,    yamlToXmlConverterStyles];
+    WebComponentBase.styles,
+    yamlToXmlConverterStyles];
 
   @property({ type: String }) inputText = '';
   @property({ type: String }) outputText = '';
@@ -18,7 +19,7 @@ export class YamlToXmlConverter extends WebComponentBase {
     this.process();
   }
 
-  private jsonToXml(obj: any, rootName = 'root'): string {
+  private jsonToXml(obj: unknown, rootName = 'root'): string {
     if (typeof obj !== 'object' || obj === null) {
       return String(obj);
     }
@@ -30,9 +31,10 @@ export class YamlToXmlConverter extends WebComponentBase {
         xml += `<item>${this.jsonToXml(item, 'item')}</item>`;
       });
     } else {
-      for (const key in obj) {
-        if (Object.prototype.hasOwnProperty.call(obj, key)) {
-          const value = obj[key];
+      const record = obj as Record<string, unknown>;
+      for (const key in record) {
+        if (Object.prototype.hasOwnProperty.call(record, key)) {
+          const value = record[key];
           if (typeof value === 'object' && value !== null) {
             xml += this.jsonToXml(value, key);
           } else {


### PR DESCRIPTION
## Summary

Follow-up to #69. Two parts:

1. **Address Copilot review comments from #69** that were valid but deferred to this PR.
2. **Phase B of the saved ESLint upgrade plan**: tighten `@typescript-eslint/no-explicit-any` from `warn` to `error` and clean up all 20 occurrences in real source code.

## Copilot review fixes (carry-over from #69)

| # | Comment | Fix |
|---|---|---|
| 1 | `scripts/css-to-ts.js` was no longer linted because the flat config ignored `scripts/**` | Replaced `scripts/**` with explicit per-file ignores and added a dedicated `files: ['scripts/css-to-ts.js']` block with Node globals |
| 2 | `engines.node: ">=18"` is too loose for ESLint 9 (which requires ≥18.18.0 per its transitive deps) | Bumped to `">=18.18.0"` |

The other two Copilot comments (#3 `while(true)`, #4 `lit/no-template-map`) were verified false positives in the previous PR (eslint:recommended v9 allows `while(true)` by default; the wedding-biodata `.map` warning was already counted in the existing 92 warnings).

## Phase B: kill `any`

Replaced 20 explicit `any` types with proper types across 11 source files:

| File(s) | Approach |
|---|---|
| `age-calculator`, `age-difference-calculator` | Typed `Partial<{ years: number; months: number; ...; total: Record<string, number \| string> }>` for the result shape |
| `htaccess-generator`, `meta-tags-generator`, `open-graph-generator` | `(this as unknown as Record<string, unknown>)[field] = ...` for dynamic property assignment |
| `csv-to-xml-converter`, `tsv-to-json-converter` | `Record<string, unknown>` / `Record<string, string>` |
| `sql-to-json-converter`, `xml-to-csv-converter`, `xml-to-yaml-converter`, `yaml-to-xml-converter` | Typed parser internals (`Record<string, unknown>` for objects, `unknown` for recursive return types, narrowing casts where needed) |
| `dns-lookup` | Typed DNS record shape `Array<{ name: string; type: number; TTL: number; data: string }>` |

Then promoted `@typescript-eslint/no-explicit-any` from `warn` → `error` in `eslint.config.js`. Future `any` usage now fails CI.

One spec update was needed: `age-calculator.spec.ts` adjusted from `result.total.days` → `result.total?.days` to match the new `Partial<...>` shape.

## Verification

| Metric | Before (#69 head) | After |
|---|---|---|
| Lint errors | 0 | 0 |
| Lint warnings | 92 | **72** (20 `no-explicit-any` warnings eliminated) |
| TypeScript `tsc --noEmit` | clean | clean |
| Test suites | 161 pass | 161 pass |
| Tests | 425 pass | 425 pass |
| `npm run validate` | OK | OK |

## Remaining lint warnings (72)

All `lit/no-template-arrow` (60) and `lit/no-template-map` (12). Both are stylistic guidance from `eslint-plugin-lit` and intentionally left at `warn` — refactoring them would touch every tool's render method and is best handled as its own focused PR.
