### PR TITLE
chore(calculators): remove $ symbol from discount/tip/SI/CI calculators (currency-neutral UI)

### DIFF
--- a/src/compound-interest-calculator/compound-interest-calculator.ts
+++ b/src/compound-interest-calculator/compound-interest-calculator.ts
@@ -33,7 +33,7 @@ export class CompoundInterestCalculator extends WebComponentBase {
     private renderInputFields() {
         return html`
             <div>
-                <label class="block mb-2 font-semibold">Principal Amount ($):</label>
+                <label class="block mb-2 font-semibold">Principal Amount:</label>
                 <input
                     type="number"
                     min="0"
@@ -100,11 +100,11 @@ export class CompoundInterestCalculator extends WebComponentBase {
             <div class="bg-blue-50 p-4 rounded-lg space-y-2">
                 <div class="flex justify-between">
                     <span class="font-semibold">Total Amount:</span>
-                    <span class="text-xl font-bold text-blue-600">$${this.totalAmount.toFixed(2)}</span>
+                    <span class="text-xl font-bold text-blue-600">${this.totalAmount.toFixed(2)}</span>
                 </div>
                 <div class="flex justify-between">
                     <span class="font-semibold">Interest Earned:</span>
-                    <span class="text-lg font-semibold text-green-600">$${this.interest.toFixed(2)}</span>
+                    <span class="text-lg font-semibold text-green-600">${this.interest.toFixed(2)}</span>
                 </div>
             </div>
         `;

--- a/src/discount-calculator/discount-calculator.ts
+++ b/src/discount-calculator/discount-calculator.ts
@@ -22,7 +22,7 @@ export class DiscountCalculator extends WebComponentBase {
         return html`
             <div class="space-y-4">
                 <div>
-                    <label class="block mb-2 font-semibold">Original Price ($):</label>
+                    <label class="block mb-2 font-semibold">Original Price:</label>
                     <input
                         type="number"
                         class="form-input w-full"
@@ -47,15 +47,15 @@ export class DiscountCalculator extends WebComponentBase {
                     <div class="bg-gray-100 p-4 rounded space-y-2">
                         <div class="flex justify-between">
                             <span>Discount Amount:</span>
-                            <span class="font-bold text-red-600">-$${this.discountAmount.toFixed(2)}</span>
+                            <span class="font-bold text-red-600">-${this.discountAmount.toFixed(2)}</span>
                         </div>
                         <div class="flex justify-between">
                             <span>You Save:</span>
-                            <span class="font-bold text-green-600">$${this.savings.toFixed(2)}</span>
+                            <span class="font-bold text-green-600">${this.savings.toFixed(2)}</span>
                         </div>
                         <div class="flex justify-between border-t pt-2">
                             <span>Final Price:</span>
-                            <span class="font-bold text-lg text-blue-600">$${this.finalPrice.toFixed(2)}</span>
+                            <span class="font-bold text-lg text-blue-600">${this.finalPrice.toFixed(2)}</span>
                         </div>
                     </div>
                 ` : ''}

--- a/src/simple-interest-calculator/simple-interest-calculator.ts
+++ b/src/simple-interest-calculator/simple-interest-calculator.ts
@@ -35,7 +35,7 @@ export class SimpleInterestCalculator extends WebComponentBase {
     private renderInputs() {
         return html`
             <div>
-                <label class="block mb-2 font-semibold">Principal Amount ($):</label>
+                <label class="block mb-2 font-semibold">Principal Amount:</label>
                 <input
                     type="number"
                     min="0"
@@ -85,11 +85,11 @@ export class SimpleInterestCalculator extends WebComponentBase {
             <div class="bg-blue-50 p-4 rounded-lg space-y-2">
                 <div class="flex justify-between">
                     <span class="font-semibold">Simple Interest:</span>
-                    <span class="text-lg font-semibold text-green-600">$${this.interest.toFixed(2)}</span>
+                    <span class="text-lg font-semibold text-green-600">${this.interest.toFixed(2)}</span>
                 </div>
                 <div class="flex justify-between">
                     <span class="font-semibold">Total Amount:</span>
-                    <span class="text-xl font-bold text-blue-600">$${this.totalAmount.toFixed(2)}</span>
+                    <span class="text-xl font-bold text-blue-600">${this.totalAmount.toFixed(2)}</span>
                 </div>
             </div>
         `;

--- a/src/tip-calculator/tip-calculator.ts
+++ b/src/tip-calculator/tip-calculator.ts
@@ -28,15 +28,15 @@ export class TipCalculator extends WebComponentBase {
             <div class="bg-gray-100 p-4 rounded space-y-2">
                 <div class="flex justify-between">
                     <span>Tip Amount:</span>
-                    <span class="font-bold">$${this.tipAmount.toFixed(2)}</span>
+                    <span class="font-bold">${this.tipAmount.toFixed(2)}</span>
                 </div>
                 <div class="flex justify-between">
                     <span>Total Amount:</span>
-                    <span class="font-bold">$${this.totalAmount.toFixed(2)}</span>
+                    <span class="font-bold">${this.totalAmount.toFixed(2)}</span>
                 </div>
                 <div class="flex justify-between border-t pt-2">
                     <span>Per Person:</span>
-                    <span class="font-bold text-lg">$${this.perPersonAmount.toFixed(2)}</span>
+                    <span class="font-bold text-lg">${this.perPersonAmount.toFixed(2)}</span>
                 </div>
             </div>
         `;
@@ -46,7 +46,7 @@ export class TipCalculator extends WebComponentBase {
         return html`
             <div class="space-y-4">
                 <div>
-                    <label class="block mb-2 font-semibold">Bill Amount ($):</label>
+                    <label class="block mb-2 font-semibold">Bill Amount:</label>
                     <input type="number" class="form-input w-full" min="0" step="0.01"
                         .value=${String(this.billAmount)}
                         @input=${(e: Event) => { this.billAmount = Number((e.target as HTMLInputElement).value); this.calculate(); }}


### PR DESCRIPTION
﻿- Remove hard-coded `$` symbol from labels and result rows in 4 calculator components so the UI is currency-neutral and works for users worldwide.
- Numeric values are no longer prefixed with a currency glyph; the surrounding captions (Original Price, Bill Amount, Principal Amount, Tip Amount, You Save, Final Price, Interest Earned, Total Amount, Per Person) already convey the meaning.
- Inputs keep `step="0.01"` and outputs keep `toFixed(2)`, so the calculators remain valid for any 2-decimal currency (USD, INR, EUR, GBP, etc.).

Files changed:
- src/discount-calculator/discount-calculator.ts (1 label, 3 result spans)
- src/tip-calculator/tip-calculator.ts (1 label, 3 result spans)
- src/simple-interest-calculator/simple-interest-calculator.ts (1 label, 2 result spans)
- src/compound-interest-calculator/compound-interest-calculator.ts (1 label, 2 result spans)

Verification:
- `npx tsc --noEmit` clean
- `npm test -- --testPathPattern="(discount|tip|simple-interest|compound-interest)-calculator"` -> 4 suites, 8 tests, all pass
- `npx eslint src/{discount,tip,simple-interest,compound-interest}-calculator/` -> 0 errors (only pre-existing arrow-in-template warnings, unchanged by this PR)
