### PR TITLE
feat(t-file-dropzone): add reusable drag-and-drop file picker component

### DIFF
--- a/src/jpg-to-webp-converter/jpg-to-webp-converter.ts
+++ b/src/jpg-to-webp-converter/jpg-to-webp-converter.ts
@@ -2,17 +2,19 @@ import { html } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { WebComponentBase } from "../_web-component/WebComponentBase.js";
 import jpgToWebpConverterStyles from "./jpg-to-webp-converter.css.js";
+import "../t-file-dropzone/index.js";
+import type { TFileDropzoneChangeDetail } from "../t-file-dropzone/t-file-dropzone.js";
 
 @customElement("jpg-to-webp-converter")
 export class JpgToWebpConverter extends WebComponentBase {
   static override styles = [
-    WebComponentBase.styles,    jpgToWebpConverterStyles];
+    WebComponentBase.styles,
+    jpgToWebpConverterStyles];
 
   @property({ type: Object }) file: File | null = null;
 
-  private handleFileChange(e: Event) {
-    const input = e.target as HTMLInputElement;
-    this.file = input.files?.[0] ?? null;
+  private handleFileChange(e: CustomEvent<TFileDropzoneChangeDetail>) {
+    this.file = e.detail.file;
   }
 
   private convert() {
@@ -55,13 +57,11 @@ export class JpgToWebpConverter extends WebComponentBase {
   override render() {
     return html`
       <div class="space-y-3">
-        <label>Select a JPG file:</label>
-        <input
-          type="file"
+        <t-file-dropzone
           accept="image/jpeg,image/jpg"
-          class="form-input"
-          @change="${this.handleFileChange}"
-        />
+          label="Drop a JPG file here or click to browse"
+          @change=${this.handleFileChange}
+        ></t-file-dropzone>
         <button
           class="btn btn-blue"
           @click="${this.convert}"

--- a/src/jpg-to-webp-converter/jpg-to-webp-converter.ts
+++ b/src/jpg-to-webp-converter/jpg-to-webp-converter.ts
@@ -58,7 +58,7 @@ export class JpgToWebpConverter extends WebComponentBase {
     return html`
       <div class="space-y-3">
         <t-file-dropzone
-          accept="image/jpeg,image/jpg"
+          accept="image/jpeg,.jpg,.jpeg"
           label="Drop a JPG file here or click to browse"
           @change=${this.handleFileChange}
         ></t-file-dropzone>

--- a/src/t-file-dropzone/index.ts
+++ b/src/t-file-dropzone/index.ts
@@ -1,0 +1,1 @@
+export * from './t-file-dropzone.js';

--- a/src/t-file-dropzone/t-file-dropzone.css
+++ b/src/t-file-dropzone/t-file-dropzone.css
@@ -1,0 +1,32 @@
+.dropzone {
+  @apply block w-full cursor-pointer rounded-lg border-2 border-dashed border-slate-300 bg-slate-50 px-4 py-8 text-center text-slate-600 transition-colors;
+}
+
+.dropzone:hover,
+.dropzone:focus-visible {
+  @apply border-blue-400 bg-blue-50 text-blue-700 outline-none;
+}
+
+.dropzone.is-dragging {
+  @apply border-blue-500 bg-blue-100 text-blue-800;
+}
+
+.dropzone[aria-disabled="true"] {
+  @apply cursor-not-allowed opacity-60;
+}
+
+.dropzone-label {
+  @apply block text-sm;
+}
+
+.dropzone-hint {
+  @apply mt-1 block text-xs text-slate-400;
+}
+
+.dropzone-file {
+  @apply mt-2 block text-sm font-medium text-slate-700;
+}
+
+.dropzone-input {
+  @apply hidden;
+}

--- a/src/t-file-dropzone/t-file-dropzone.spec.ts
+++ b/src/t-file-dropzone/t-file-dropzone.spec.ts
@@ -1,0 +1,23 @@
+import { LitElement } from 'lit';
+import { TFileDropzone } from './t-file-dropzone.js';
+
+describe('t-file-dropzone web component test', () => {
+    const componentTag = 't-file-dropzone';
+
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    it('should render web component', async () => {
+        const component = document.createElement(componentTag) as LitElement;
+        document.body.appendChild(component);
+        await component.updateComplete;
+        expect(component).toBeTruthy();
+        expect(component.renderRoot).toBeTruthy();
+    });
+
+    it('should be an instance of TFileDropzone', () => {
+        const component = document.createElement(componentTag) as TFileDropzone;
+        expect(component).toBeInstanceOf(TFileDropzone);
+    });
+});

--- a/src/t-file-dropzone/t-file-dropzone.ts
+++ b/src/t-file-dropzone/t-file-dropzone.ts
@@ -1,0 +1,187 @@
+import { html } from 'lit';
+import { WebComponentBase } from '../_web-component/WebComponentBase.js';
+import tFileDropzoneStyles from './t-file-dropzone.css.js';
+import { customElement, property, state } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+
+export interface TFileDropzoneChangeDetail {
+    file: File | null;
+    files: File[];
+}
+
+@customElement('t-file-dropzone')
+export class TFileDropzone extends WebComponentBase {
+    static override styles = [WebComponentBase.styles, tFileDropzoneStyles];
+
+    @property({ type: String })
+    accept = '*';
+
+    @property({ type: Boolean })
+    multiple = false;
+
+    @property({ type: Boolean })
+    disabled = false;
+
+    @property({ type: String })
+    label = 'Drop a file here or click to browse';
+
+    @property({ type: String })
+    hint = '';
+
+    @property({ attribute: false })
+    file: File | null = null;
+
+    @property({ attribute: false })
+    files: File[] = [];
+
+    @state()
+    private isDragging = false;
+
+    private get inputEl(): HTMLInputElement | null {
+        return this.renderRoot.querySelector('input[type="file"]');
+    }
+
+    private openPicker = () => {
+        if (this.disabled) {
+            return;
+        }
+
+        this.inputEl?.click();
+    };
+
+    private onKeyDown = (e: KeyboardEvent) => {
+        if (this.disabled) {
+            return;
+        }
+
+        if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            this.openPicker();
+        }
+    };
+
+    private onInputChange = (e: Event) => {
+        const input = e.target as HTMLInputElement;
+        const list = input.files ? Array.from(input.files) : [];
+        this.commitFiles(list);
+    };
+
+    private onDragOver = (e: DragEvent) => {
+        if (this.disabled) {
+            return;
+        }
+
+        e.preventDefault();
+        if (e.dataTransfer) {
+            e.dataTransfer.dropEffect = 'copy';
+        }
+
+        if (!this.isDragging) {
+            this.isDragging = true;
+        }
+    };
+
+    private onDragLeave = (e: DragEvent) => {
+        if (e.currentTarget === e.target) {
+            this.isDragging = false;
+        }
+    };
+
+    private onDrop = (e: DragEvent) => {
+        if (this.disabled) {
+            return;
+        }
+
+        e.preventDefault();
+        this.isDragging = false;
+        const dropped = e.dataTransfer?.files ? Array.from(e.dataTransfer.files) : [];
+        const accepted = dropped.filter(f => this.matchesAccept(f));
+        const rejectedCount = dropped.length - accepted.length;
+        if (rejectedCount > 0) {
+            console.warn(`t-file-dropzone: ${rejectedCount} file(s) rejected (did not match accept="${this.accept}")`);
+        }
+
+        if (!accepted.length) {
+            return;
+        }
+
+        this.commitFiles(accepted);
+    };
+
+    private matchesAccept(file: File): boolean {
+        if (!this.accept || this.accept === '*' || this.accept === '*/*') {
+            return true;
+        }
+
+        const tokens = this.accept.split(',').map(t => t.trim().toLowerCase()).filter(Boolean);
+        if (!tokens.length) {
+            return true;
+        }
+
+        const name = file.name.toLowerCase();
+        const type = file.type.toLowerCase();
+        return tokens.some(token => {
+            if (token.startsWith('.')) {
+                return name.endsWith(token);
+            }
+
+            if (token.endsWith('/*')) {
+                const prefix = token.slice(0, -1);
+                return type.startsWith(prefix);
+            }
+
+            return type === token;
+        });
+    }
+
+    private commitFiles(list: File[]) {
+        const trimmed = this.multiple ? list : list.slice(0, 1);
+        this.files = trimmed;
+        this.file = trimmed[0] ?? null;
+        this.dispatchEvent(new CustomEvent<TFileDropzoneChangeDetail>('change', {
+            detail: { file: this.file, files: this.files },
+            bubbles: true,
+            composed: true,
+        }));
+    }
+
+    override render() {
+        const fileLabel = this.files.length > 1
+            ? `${this.files.length} files selected`
+            : this.file?.name ?? '';
+
+        return html`
+            <div
+                class=${classMap({ dropzone: true, 'is-dragging': this.isDragging })}
+                role="button"
+                tabindex=${this.disabled ? -1 : 0}
+                aria-disabled=${this.disabled ? 'true' : 'false'}
+                aria-label=${this.label}
+                @click=${this.openPicker}
+                @keydown=${this.onKeyDown}
+                @dragenter=${this.onDragOver}
+                @dragover=${this.onDragOver}
+                @dragleave=${this.onDragLeave}
+                @drop=${this.onDrop}
+            >
+                <span class="dropzone-label">${this.label}</span>
+                ${this.hint ? html`<span class="dropzone-hint">${this.hint}</span>` : null}
+                ${fileLabel ? html`<span class="dropzone-file">${fileLabel}</span>` : null}
+                <input
+                    class="dropzone-input"
+                    type="file"
+                    accept=${this.accept}
+                    ?multiple=${this.multiple}
+                    ?disabled=${this.disabled}
+                    @change=${this.onInputChange}
+                />
+            </div>
+        `;
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        't-file-dropzone': TFileDropzone;
+    }
+}

--- a/src/t-file-dropzone/t-file-dropzone.ts
+++ b/src/t-file-dropzone/t-file-dropzone.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit';
+import { html, nothing } from 'lit';
 import { WebComponentBase } from '../_web-component/WebComponentBase.js';
 import tFileDropzoneStyles from './t-file-dropzone.css.js';
 import { customElement, property, state } from 'lit/decorators.js';
@@ -14,7 +14,7 @@ export class TFileDropzone extends WebComponentBase {
     static override styles = [WebComponentBase.styles, tFileDropzoneStyles];
 
     @property({ type: String })
-    accept = '*';
+    accept = '';
 
     @property({ type: Boolean })
     multiple = false;
@@ -67,11 +67,13 @@ export class TFileDropzone extends WebComponentBase {
     };
 
     private onDragOver = (e: DragEvent) => {
+        // Always preventDefault so the browser doesn't navigate to the dropped
+        // file when this dropzone is disabled.
+        e.preventDefault();
         if (this.disabled) {
             return;
         }
 
-        e.preventDefault();
         if (e.dataTransfer) {
             e.dataTransfer.dropEffect = 'copy';
         }
@@ -88,11 +90,13 @@ export class TFileDropzone extends WebComponentBase {
     };
 
     private onDrop = (e: DragEvent) => {
+        // Always preventDefault so a disabled dropzone doesn't let the browser
+        // open/navigate to the dropped file.
+        e.preventDefault();
         if (this.disabled) {
             return;
         }
 
-        e.preventDefault();
         this.isDragging = false;
         const dropped = e.dataTransfer?.files ? Array.from(e.dataTransfer.files) : [];
         const accepted = dropped.filter(f => this.matchesAccept(f));
@@ -120,6 +124,18 @@ export class TFileDropzone extends WebComponentBase {
 
         const name = file.name.toLowerCase();
         const type = file.type.toLowerCase();
+        // File.type can be empty for some dropped files (e.g. unknown ext).
+        // Stay lenient and fall back to extension-only matching in that case so
+        // the drop UX matches what the native picker would have allowed.
+        if (!type) {
+            const extTokens = tokens.filter(t => t.startsWith('.'));
+            if (!extTokens.length) {
+                return true;
+            }
+
+            return extTokens.some(t => name.endsWith(t));
+        }
+
         return tokens.some(token => {
             if (token.startsWith('.')) {
                 return name.endsWith(token);
@@ -170,7 +186,7 @@ export class TFileDropzone extends WebComponentBase {
                 <input
                     class="dropzone-input"
                     type="file"
-                    accept=${this.accept}
+                    accept=${this.accept || nothing}
                     ?multiple=${this.multiple}
                     ?disabled=${this.disabled}
                     @change=${this.onInputChange}


### PR DESCRIPTION
## Summary

Adds a reusable `<t-file-dropzone>` web component that wraps file selection with drag-and-drop, click-to-browse, and keyboard activation. Migrates `jpg-to-webp-converter` as proof-of-fit consumer.

This unblocks PR 2 (`image-resizer` + `image-compressor`) which both consume this component.

## What's new

**`src/t-file-dropzone/`** — `t-`-prefixed reusable component (mirrors `t-copy-button` pattern; auto-skipped from `demo/tools.js` by scaffolder).

- Props: `accept` (passthrough, e.g. `image/*`), `multiple`, `disabled`, `label`, `hint`.
- Output props: `file: File | null`, `files: File[]`.
- Emits a typed `change` CustomEvent with `detail: { file, files }` — bubbles + composed so consumers use `e.detail.file` (not `input.files`).
- Drag UX: `dragenter/over/leave/drop` with `is-dragging` class for hover styling.
- Lenient `accept` validation on drop (mime-type, `type/*` wildcard, and `.ext` suffix); warns on rejection (no throw).
- A11y: `role="button"`, `tabindex=0`, Enter / Space activates browse.

## Migration

- `jpg-to-webp-converter` now uses `<t-file-dropzone accept="image/jpeg,image/jpg" @change=…>`. Handler reads `e.detail.file`.
- Other existing file-input tools (`csv-to-json-converter`, `image-to-base64`, `text-to-speech`, image converters, etc.) are intentionally **not** migrated in this PR to keep the review tight; tracked for follow-ups.

## Verification

- `npx tsc --noEmit` — clean.
- `npx eslint src/t-file-dropzone src/jpg-to-webp-converter` — 0 errors.
- `npm test -- --testPathPattern="(t-file-dropzone|jpg-to-webp-converter)"` — 2 suites, 4 tests pass.

## Out of scope (v1)

EXIF preservation, drag-to-reorder for multi-file, file-size-limit prop, thumbnail slot, paste-from-clipboard, "remove file" button (re-upload replaces).
