### PR TITLE
chore: migrate 7 converters to <t-file-dropzone>

### DIFF
--- a/src/csv-to-json-converter/csv-to-json-converter.ts
+++ b/src/csv-to-json-converter/csv-to-json-converter.ts
@@ -3,6 +3,8 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { WebComponentBase } from '../_web-component/WebComponentBase.js';
 import csvToJsonConverterStyles from './csv-to-json-converter.css.js';
 import '../t-copy-button/index.js';
+import '../t-file-dropzone/index.js';
+import type { TFileDropzoneChangeDetail } from '../t-file-dropzone/t-file-dropzone.js';
 
 @customElement('csv-to-json-converter')
 export class CsvToJsonConverter extends WebComponentBase {
@@ -61,9 +63,8 @@ export class CsvToJsonConverter extends WebComponentBase {
     }
   }
 
-  private handleFileUpload(event: Event) {
-    const inputElement = event.target as HTMLInputElement;
-    const file = inputElement.files?.[0];
+  private handleFileUpload(event: CustomEvent<TFileDropzoneChangeDetail>) {
+    const file = event.detail.file;
 
     if (file) {
       const reader = new FileReader();
@@ -114,7 +115,11 @@ export class CsvToJsonConverter extends WebComponentBase {
             placeholder="Paste CSV data here or upload a file"
             rows="10"
           ></textarea>
-          <input type="file" accept=".csv" @change="${this.handleFileUpload}" class="file-input" />
+          <t-file-dropzone
+            accept=".csv,text/csv"
+            label="Drop a CSV file here or click to browse"
+            @change=${this.handleFileUpload}
+          ></t-file-dropzone>
           <button class="btn btn-blue mt-2" @click="${this.convertCsvToJson}">Convert to JSON</button>
         </div>
 

--- a/src/json-to-csv-converter/json-to-csv-converter.ts
+++ b/src/json-to-csv-converter/json-to-csv-converter.ts
@@ -3,6 +3,8 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { WebComponentBase } from '../_web-component/WebComponentBase.js';
 import jsonToCsvConverterStyles from './json-to-csv-converter.css.js';
 import '../t-copy-button/index.js';
+import '../t-file-dropzone/index.js';
+import type { TFileDropzoneChangeDetail } from '../t-file-dropzone/t-file-dropzone.js';
 
 @customElement('json-to-csv-converter')
 export class JsonToCsvConverter extends WebComponentBase {
@@ -18,9 +20,8 @@ export class JsonToCsvConverter extends WebComponentBase {
         this.jsonString = inputElement.value;
     }
 
-    private onJsonFileUpload(event: Event) {
-        const inputElement = event.target as HTMLInputElement;
-        const file = inputElement.files ? inputElement.files[0] : null;
+    private onJsonFileUpload(event: CustomEvent<TFileDropzoneChangeDetail>) {
+        const file = event.detail.file;
         if (file) {
             const reader = new FileReader();
             reader.onload = (e) => {
@@ -103,7 +104,11 @@ export class JsonToCsvConverter extends WebComponentBase {
                         placeholder="Paste JSON data here or upload a JSON file"
                         rows="10"
                     ></textarea>
-                    <input class="file-input" type="file" @change=${this.onJsonFileUpload} accept=".json" />
+                    <t-file-dropzone
+                        accept=".json,application/json,text/json"
+                        label="Drop a JSON file here or click to browse"
+                        @change=${this.onJsonFileUpload}
+                    ></t-file-dropzone>
                     <button class="btn btn-blue mt-2" @click=${this.convertJsonToCsv}>Convert to CSV</button>
                 </div>
 

--- a/src/json-to-xml-converter/json-to-xml-converter.ts
+++ b/src/json-to-xml-converter/json-to-xml-converter.ts
@@ -2,6 +2,8 @@ import { html } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { WebComponentBase } from "../_web-component/WebComponentBase.js";
 import jsonToXmlConverterStyles from "./json-to-xml-converter.css.js";
+import "../t-file-dropzone/index.js";
+import type { TFileDropzoneChangeDetail } from "../t-file-dropzone/t-file-dropzone.js";
 
 interface JsonObject {
   [key: string]: unknown;
@@ -21,14 +23,14 @@ type JsonValue =
 @customElement("json-to-xml-converter")
 export class JsonToXmlConverter extends WebComponentBase {
   static override styles = [
-    WebComponentBase.styles,    jsonToXmlConverterStyles];
+    WebComponentBase.styles,
+    jsonToXmlConverterStyles];
 
   @property({ type: Object }) file: File | null = null;
   @property({ type: String }) error = "";
 
-  private handleFileChange(e: Event) {
-    const input = e.target as HTMLInputElement;
-    this.file = input.files?.[0] ?? null;
+  private handleFileChange(e: CustomEvent<TFileDropzoneChangeDetail>) {
+    this.file = e.detail.file;
     this.error = "";
   }
 
@@ -205,13 +207,11 @@ export class JsonToXmlConverter extends WebComponentBase {
   override render() {
     return html`
       <div class="space-y-3">
-        <label>Select a JSON file:</label>
-        <input
-          type="file"
+        <t-file-dropzone
           accept="application/json,text/json,.json"
-          class="form-input"
-          @change="${this.handleFileChange}"
-        />
+          label="Drop a JSON file here or click to browse"
+          @change=${this.handleFileChange}
+        ></t-file-dropzone>
         <button
           class="btn btn-blue"
           @click="${this.convert}"

--- a/src/png-to-webp-converter/png-to-webp-converter.ts
+++ b/src/png-to-webp-converter/png-to-webp-converter.ts
@@ -2,17 +2,19 @@ import { html } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { WebComponentBase } from "../_web-component/WebComponentBase.js";
 import pngToWebpConverterStyles from "./png-to-webp-converter.css.js";
+import "../t-file-dropzone/index.js";
+import type { TFileDropzoneChangeDetail } from "../t-file-dropzone/t-file-dropzone.js";
 
 @customElement("png-to-webp-converter")
 export class PngToWebpConverter extends WebComponentBase {
   static override styles = [
-    WebComponentBase.styles,    pngToWebpConverterStyles];
+    WebComponentBase.styles,
+    pngToWebpConverterStyles];
 
   @property({ type: Object }) file: File | null = null;
 
-  private handleFileChange(e: Event) {
-    const input = e.target as HTMLInputElement;
-    this.file = input.files?.[0] ?? null;
+  private handleFileChange(e: CustomEvent<TFileDropzoneChangeDetail>) {
+    this.file = e.detail.file;
   }
 
   private convert() {
@@ -55,13 +57,11 @@ export class PngToWebpConverter extends WebComponentBase {
   override render() {
     return html`
       <div class="space-y-3">
-        <label>Select a PNG file:</label>
-        <input
-          type="file"
-          accept="image/png"
-          class="form-input"
-          @change="${this.handleFileChange}"
-        />
+        <t-file-dropzone
+          accept="image/png,.png"
+          label="Drop a PNG file here or click to browse"
+          @change=${this.handleFileChange}
+        ></t-file-dropzone>
         <button
           class="btn btn-blue"
           @click="${this.convert}"

--- a/src/webp-to-jpg-converter/webp-to-jpg-converter.ts
+++ b/src/webp-to-jpg-converter/webp-to-jpg-converter.ts
@@ -2,17 +2,19 @@ import { html } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { WebComponentBase } from "../_web-component/WebComponentBase.js";
 import webpToJpgConverterStyles from "./webp-to-jpg-converter.css.js";
+import "../t-file-dropzone/index.js";
+import type { TFileDropzoneChangeDetail } from "../t-file-dropzone/t-file-dropzone.js";
 
 @customElement("webp-to-jpg-converter")
 export class WebpToJpgConverter extends WebComponentBase {
   static override styles = [
-    WebComponentBase.styles,    webpToJpgConverterStyles];
+    WebComponentBase.styles,
+    webpToJpgConverterStyles];
 
   @property({ type: Object }) file: File | null = null;
 
-  private handleFileChange(e: Event) {
-    const input = e.target as HTMLInputElement;
-    this.file = input.files?.[0] ?? null;
+  private handleFileChange(e: CustomEvent<TFileDropzoneChangeDetail>) {
+    this.file = e.detail.file;
   }
 
   private convert() {
@@ -55,13 +57,11 @@ export class WebpToJpgConverter extends WebComponentBase {
   override render() {
     return html`
       <div class="space-y-3">
-        <label>Select a WebP file:</label>
-        <input
-          type="file"
-          accept="image/webp"
-          class="form-input"
-          @change="${this.handleFileChange}"
-        />
+        <t-file-dropzone
+          accept="image/webp,.webp"
+          label="Drop a WebP file here or click to browse"
+          @change=${this.handleFileChange}
+        ></t-file-dropzone>
         <button
           class="btn btn-blue"
           @click="${this.convert}"

--- a/src/webp-to-png-converter/webp-to-png-converter.ts
+++ b/src/webp-to-png-converter/webp-to-png-converter.ts
@@ -2,17 +2,19 @@ import { html } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { WebComponentBase } from "../_web-component/WebComponentBase.js";
 import webpToPngConverterStyles from "./webp-to-png-converter.css.js";
+import "../t-file-dropzone/index.js";
+import type { TFileDropzoneChangeDetail } from "../t-file-dropzone/t-file-dropzone.js";
 
 @customElement("webp-to-png-converter")
 export class WebpToPngConverter extends WebComponentBase {
   static override styles = [
-    WebComponentBase.styles,    webpToPngConverterStyles];
+    WebComponentBase.styles,
+    webpToPngConverterStyles];
 
   @property({ type: Object }) file: File | null = null;
 
-  private handleFileChange(e: Event) {
-    const input = e.target as HTMLInputElement;
-    this.file = input.files?.[0] ?? null;
+  private handleFileChange(e: CustomEvent<TFileDropzoneChangeDetail>) {
+    this.file = e.detail.file;
   }
 
   private convert() {
@@ -55,13 +57,11 @@ export class WebpToPngConverter extends WebComponentBase {
   override render() {
     return html`
       <div class="space-y-3">
-        <label>Select a WebP file:</label>
-        <input
-          type="file"
-          accept="image/webp"
-          class="form-input"
-          @change="${this.handleFileChange}"
-        />
+        <t-file-dropzone
+          accept="image/webp,.webp"
+          label="Drop a WebP file here or click to browse"
+          @change=${this.handleFileChange}
+        ></t-file-dropzone>
         <button
           class="btn btn-blue"
           @click="${this.convert}"

--- a/src/xml-to-json-converter/xml-to-json-converter.ts
+++ b/src/xml-to-json-converter/xml-to-json-converter.ts
@@ -2,6 +2,8 @@ import { html } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { WebComponentBase } from "../_web-component/WebComponentBase.js";
 import xmlToJsonConverterStyles from "./xml-to-json-converter.css.js";
+import "../t-file-dropzone/index.js";
+import type { TFileDropzoneChangeDetail } from "../t-file-dropzone/t-file-dropzone.js";
 
 interface JsonObject {
   [key: string]: unknown;
@@ -12,14 +14,14 @@ interface JsonObject {
 @customElement("xml-to-json-converter")
 export class XmlToJsonConverter extends WebComponentBase {
   static override styles = [
-    WebComponentBase.styles,    xmlToJsonConverterStyles];
+    WebComponentBase.styles,
+    xmlToJsonConverterStyles];
 
   @property({ type: Object }) file: File | null = null;
   @property({ type: String }) error = "";
 
-  private handleFileChange(e: Event) {
-    const input = e.target as HTMLInputElement;
-    this.file = input.files?.[0] ?? null;
+  private handleFileChange(e: CustomEvent<TFileDropzoneChangeDetail>) {
+    this.file = e.detail.file;
     this.error = "";
   }
 
@@ -160,13 +162,11 @@ export class XmlToJsonConverter extends WebComponentBase {
   override render() {
     return html`
       <div class="space-y-3">
-        <label>Select an XML file:</label>
-        <input
-          type="file"
+        <t-file-dropzone
           accept="application/xml,text/xml,.xml"
-          class="form-input"
-          @change="${this.handleFileChange}"
-        />
+          label="Drop an XML file here or click to browse"
+          @change=${this.handleFileChange}
+        ></t-file-dropzone>
         <button
           class="btn btn-blue"
           @click="${this.convert}"


### PR DESCRIPTION
Migrates 7 converters from native `<input type=file>` to the reusable `<t-file-dropzone>` component (PR #74).

**Tools migrated**
- `csv-to-json-converter` — accept `.csv,text/csv`
- `json-to-csv-converter` — accept `.json,application/json,text/json`
- `json-to-xml-converter` — accept `application/json,text/json,.json`
- `xml-to-json-converter` — accept `application/xml,text/xml,.xml`
- `png-to-webp-converter` — accept `image/png,.png`
- `webp-to-jpg-converter` — accept `image/webp,.webp`
- `webp-to-png-converter` — accept `image/webp,.webp`

**Pattern**
Each handler now reads `e.detail.file` from `TFileDropzoneChangeDetail` instead of pulling the first file off `HTMLInputElement.files`. Accept lists include both MIME and extension tokens for better drag-and-drop matching across browsers/OSes.

**Verification**
- `tsc --noEmit` clean
- `eslint` 0 errors on all 7 tools

Stacks on top of #74 (already merged).