### PR TITLE
feat(direct-to-telegram): add Telegram direct chat tool

### DIFF
--- a/demo/tools.js
+++ b/demo/tools.js
@@ -36,6 +36,7 @@ const tools = [
     "date-time-format",
     "days-between-dates",
     "diff-checker",
+    "direct-to-telegram",
     "direct-to-whatsapp",
     "discount-calculator",
     "dns-lookup",

--- a/src/direct-to-telegram/direct-to-telegram.spec.ts
+++ b/src/direct-to-telegram/direct-to-telegram.spec.ts
@@ -1,0 +1,31 @@
+import { LitElement } from 'lit';
+import { DirectToTelegram } from './direct-to-telegram.js';
+
+describe('direct-to-telegram web component test', () => {
+    const componentTag = 'direct-to-telegram';
+
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    it('should render web component', async () => {
+        const component = document.createElement(componentTag) as LitElement;
+        document.body.appendChild(component);
+        await component.updateComplete;
+        expect(component).toBeTruthy();
+        expect(component.renderRoot).toBeTruthy();
+
+        const renderedText = component.renderRoot.querySelector('button.btn')?.textContent;
+        expect(renderedText).toEqual('Open in Telegram');
+    });
+
+    it('should be an instance of DirectToTelegram', () => {
+        const component = document.createElement(componentTag) as DirectToTelegram;
+        expect(component).toBeInstanceOf(DirectToTelegram);
+    });
+
+    it('should have initial target property as empty string', () => {
+        const component = document.createElement(componentTag) as DirectToTelegram;
+        expect(component.target).toBe("");
+    });
+});

--- a/src/direct-to-telegram/direct-to-telegram.ts
+++ b/src/direct-to-telegram/direct-to-telegram.ts
@@ -49,7 +49,14 @@ export class DirectToTelegram extends WebComponentBase {
 
   private onTargetChange(e: Event) {
     const target = e.target as HTMLInputElement;
-    this.target = target?.value?.replace(/ |-/g, "") || "";
+    const value = target?.value || "";
+    // Only strip spaces/dashes for phone-like input (digits with optional +,
+    // spaces, dashes). For usernames, just trim outer whitespace — stripping
+    // hyphens would silently turn an invalid username (e.g. "john-doe") into
+    // a different valid one ("johndoe") and open the wrong chat.
+    this.target = /^[\s+0-9-]+$/.test(value)
+      ? value.replace(/[\s-]/g, "")
+      : value.trim();
   }
 
   override render() {

--- a/src/direct-to-telegram/direct-to-telegram.ts
+++ b/src/direct-to-telegram/direct-to-telegram.ts
@@ -1,0 +1,88 @@
+import { html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { WebComponentBase } from '../_web-component/WebComponentBase.js';
+import directToTelegramStyles from './direct-to-telegram.css.js';
+
+@customElement('direct-to-telegram')
+export class DirectToTelegram extends WebComponentBase {
+  static override styles = [WebComponentBase.styles, directToTelegramStyles];
+
+  @property()
+  target = "";
+
+  private buildUrl(): string | null {
+    const value = this.target.trim();
+    if (!value) {
+      return null;
+    }
+
+    // Phone with country code (digits, optional leading +)
+    if (/^\+?[0-9]{9,15}$/.test(value)) {
+      const digits = value.replace(/\D/g, "");
+      return `https://t.me/+${digits}`;
+    }
+
+    // Telegram username (5–32 chars, starts with letter, allows leading @)
+    if (/^@?[A-Za-z][A-Za-z0-9_]{4,31}$/.test(value)) {
+      return `https://t.me/${value.replace(/^@/, "")}`;
+    }
+
+    return null;
+  }
+
+  validateForm(e: FormDataEvent) {
+    const url = this.buildUrl();
+    if (!url) {
+      e.preventDefault();
+      return false;
+    }
+
+    e.preventDefault();
+    const form = e.target as HTMLFormElement;
+    const textarea = form?.elements.namedItem("text") as HTMLTextAreaElement | null;
+    const message = textarea?.value?.trim() || "";
+    const finalUrl = message ? `${url}?text=${encodeURIComponent(message)}` : url;
+
+    window.location.href = finalUrl;
+    return false;
+  }
+
+  private onTargetChange(e: Event) {
+    const target = e.target as HTMLInputElement;
+    this.target = target?.value?.replace(/ |-/g, "") || "";
+  }
+
+  override render() {
+    return html`
+      <form action="https://t.me/" method="GET" @submit=${this.validateForm}>
+        <div class="grid grid-cols-1 gap-4">
+          <label class="block">
+            <span>Telegram username (e.g. @durov) or phone with country code, e.g. +919876543210</span>
+            <input
+              name="target"
+              class="form-input"
+              autofocus
+              placeholder="@username or +919876543210"
+              .value=${this.target}
+              @input=${this.onTargetChange} />
+          </label>
+          <label class="block">
+            <span>Message (optional)</span>
+            <textarea
+              name="text"
+              class="form-textarea"
+              placeholder="Message (optional)"></textarea>
+          </label>
+          <div class="text-end">
+            <button type="submit" class="btn btn-blue">Open in Telegram</button>
+          </div>
+      </div>
+    </form>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'direct-to-telegram': DirectToTelegram;
+  }
+}

--- a/src/direct-to-telegram/index.ts
+++ b/src/direct-to-telegram/index.ts
@@ -1,0 +1,1 @@
+export * from './direct-to-telegram.js';


### PR DESCRIPTION
Adds a new `direct-to-telegram` tool, mirroring the structure of `direct-to-whatsapp`.

## What
- New web component `<direct-to-telegram>` at src/direct-to-telegram/.
- Single `target` field accepting a Telegram username (with or without `@`) or a phone number with country code.
- Optional message field; appended as `?text=` (best-effort prefill — works in Telegram Web/Desktop).
- On submit:
  - phone-like input -> `https://t.me/+{digits}`
  - username -> `https://t.me/{username}`
- Same form layout, Tailwind classes, and validation/handler shape as `direct-to-whatsapp` for consistency.

## Verification
- `npm run css` generates `direct-to-telegram.css.ts`.
- `npm test -- direct-to-telegram` -> 3/3 passing.
- `npx eslint src/direct-to-telegram` -> clean.