### PR TITLE
fix: web-component dark mode (shadow-DOM) + percentage-calculator improvements

### DIFF
--- a/scripts/css-to-ts.js
+++ b/scripts/css-to-ts.js
@@ -84,6 +84,13 @@ export async function transformCssToTs(cssFile) {
 
             const preambleParts = ["@reference 'tailwindcss/theme';"];
 
+            // These tools ship as Shadow-DOM web components. Consumers toggle dark
+            // mode with a `.dark` class on an ancestor (<html>/<body>/wrapper), which
+            // a plain `@media (prefers-color-scheme)` rule cannot observe. WebComponentBase
+            // mirrors that theme onto the host as `.dark`, so map Tailwind's `dark:`
+            // variant to `:host(.dark)` instead of the OS media query.
+            preambleParts.push('@custom-variant dark (&:is(:host(.dark) *));');
+
             // Shared @utility imports only for tool CSS files (not _styles/ files
             // like grid.css, table.css, utils.css which are plain CSS)
             if (!isStylesDir) {
@@ -115,11 +122,23 @@ export async function transformCssToTs(cssFile) {
             cssString = stripTailwindOverhead(cssString);
         }
 
+        // Escape for safe embedding inside a JS template literal (lit `css`).
+        // Tailwind emits escaped selectors like `.dark\:bg-gray-800` and
+        // `.bg-green-900\/30`. Without escaping, the template literal collapses
+        // `\:` → `:` (and `\/` → `/`, `\2014` → invalid), corrupting the selector
+        // so the browser silently drops the rule — which breaks every `dark:`,
+        // `hover:`, `sm:` … variant utility. Double the backslashes (and escape
+        // backticks / `${`) so the runtime CSS keeps the required backslashes.
+        const escapedCssString = cssString
+            .replace(/\\/g, '\\\\')
+            .replace(/`/g, '\\`')
+            .replace(/\$\{/g, '\\${');
+
         // write .css.ts file
         fs.writeFileSync(`${cssFile}.ts`, `
 // THIS IS AUTO GENERATED FILE, DO NOT MAKE ANY CHANGES HERE.
 import { css } from 'lit';
-const ${variableName} = css\`${cssString}\`;
+const ${variableName} = css\`${escapedCssString}\`;
 export default ${variableName}`);
     } catch (err) {
         console.error(err);

--- a/src/_web-component/WebComponentBase.ts
+++ b/src/_web-component/WebComponentBase.ts
@@ -50,10 +50,34 @@ export abstract class WebComponentBase extends LitElement {
         this._darkMediaQuery?.removeEventListener('change', this._syncDarkMode);
     }
 
+    private _hasDarkAncestor(): boolean {
+        // Walk the composed ancestor chain (crossing shadow boundaries) starting
+        // OUTSIDE this host. Excluding `this` is essential: once we mirror `.dark`
+        // onto the host, `closest('.dark')` would keep matching itself and could
+        // never fall back to light. Crossing shadow roots also lets nested
+        // components (e.g. <t-copy-button>) inherit a dark outer host.
+        let node: Node | null = this.parentNode;
+
+        while (node) {
+            if (node instanceof ShadowRoot) {
+                node = node.host;
+                continue;
+            }
+
+            if (node instanceof Element && node.classList.contains('dark')) {
+                return true;
+            }
+
+            node = node.parentNode;
+        }
+
+        return false;
+    }
+
     private _syncDarkMode = () => {
         const prefersDark = typeof window.matchMedia === 'function'
             && window.matchMedia('(prefers-color-scheme: dark)').matches;
-        const isDark = this.closest('.dark') !== null || prefersDark;
+        const isDark = this._hasDarkAncestor() || prefersDark;
 
         this.classList.toggle('dark', isDark);
     };

--- a/src/_web-component/WebComponentBase.ts
+++ b/src/_web-component/WebComponentBase.ts
@@ -12,4 +12,49 @@ export abstract class WebComponentBase extends LitElement {
     config?: IConfigBase;
 
     static override styles = baseStyles as CSSResultGroup;
+
+    private _darkObserver?: MutationObserver;
+    private _darkMediaQuery?: MediaQueryList;
+
+    override connectedCallback() {
+        super.connectedCallback();
+        this._syncDarkMode();
+
+        // Consumers toggle dark mode with a `.dark` class on an ancestor
+        // (typically <html> or <body>). Shadow DOM hides that from descendant
+        // selectors, so we mirror it onto this host element as `.dark` and the
+        // compiled CSS targets `:host(.dark)`. Watch the common theme roots so
+        // toggles are reflected live.
+        this._darkObserver = new MutationObserver(this._syncDarkMode);
+        this._darkObserver.observe(document.documentElement, {
+            attributes: true,
+            attributeFilter: ['class'],
+        });
+
+        if (document.body) {
+            this._darkObserver.observe(document.body, {
+                attributes: true,
+                attributeFilter: ['class'],
+            });
+        }
+
+        if (typeof window.matchMedia === 'function') {
+            this._darkMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+            this._darkMediaQuery.addEventListener('change', this._syncDarkMode);
+        }
+    }
+
+    override disconnectedCallback() {
+        super.disconnectedCallback();
+        this._darkObserver?.disconnect();
+        this._darkMediaQuery?.removeEventListener('change', this._syncDarkMode);
+    }
+
+    private _syncDarkMode = () => {
+        const prefersDark = typeof window.matchMedia === 'function'
+            && window.matchMedia('(prefers-color-scheme: dark)').matches;
+        const isDark = this.closest('.dark') !== null || prefersDark;
+
+        this.classList.toggle('dark', isDark);
+    };
 }

--- a/src/percentage-calculator/percentage-calculator.spec.ts
+++ b/src/percentage-calculator/percentage-calculator.spec.ts
@@ -162,6 +162,21 @@ describe('percentage-calculator web component test', () => {
         expect(result(component, 1)).toBe('—');
     });
 
+    it('should not expose copy controls while results are empty', async () => {
+        const component = await mount();
+
+        expect(component.renderRoot.querySelectorAll('t-copy-button').length).toBe(0);
+    });
+
+    it('should give the copy button the formatted result once computed', async () => {
+        const component = await mount();
+        await setInputs(component, { 0: '10', 1: '200' });
+
+        const copyButtons = component.renderRoot.querySelectorAll('t-copy-button');
+        expect(copyButtons.length).toBe(1);
+        expect((copyButtons[0] as HTMLElement & { text: string }).text).toBe('20');
+    });
+
     afterEach(() => {
         document.body.innerHTML = '';
     });

--- a/src/percentage-calculator/percentage-calculator.spec.ts
+++ b/src/percentage-calculator/percentage-calculator.spec.ts
@@ -4,12 +4,32 @@ import { PercentageCalculator } from "./percentage-calculator.js";
 describe('percentage-calculator web component test', () => {
 
     const componentTag = "percentage-calculator";
-    
-    it('should render web component', async () => {
-        const component = window.document.createElement(componentTag) as LitElement;
-        document.body.appendChild(component);
 
+    async function mount() {
+        const component = window.document.createElement(componentTag) as PercentageCalculator;
+        document.body.appendChild(component);
         await component.updateComplete;
+        return component;
+    }
+
+    async function setInputs(component: LitElement, values: Record<number, string>) {
+        const inputs = component.renderRoot.querySelectorAll('input');
+        for (const [index, value] of Object.entries(values)) {
+            const input = inputs[Number(index)] as HTMLInputElement;
+            input.value = value;
+            input.dispatchEvent(new Event('input'));
+        }
+        await (component as PercentageCalculator).updateComplete;
+    }
+
+    function result(component: LitElement, id: number): string {
+        return component.renderRoot
+            .querySelector(`[data-testid="result-${id}"]`)
+            ?.textContent?.trim() ?? '';
+    }
+
+    it('should render web component', async () => {
+        const component = await mount();
 
         expect(component).toBeTruthy();
         expect(component.renderRoot).toBeTruthy();
@@ -20,84 +40,126 @@ describe('percentage-calculator web component test', () => {
         expect(component).toBeInstanceOf(PercentageCalculator);
     });
 
-    it('should render all three calculators', async () => {
-        const component = window.document.createElement(componentTag) as LitElement;
-        document.body.appendChild(component);
-        await component.updateComplete;
+    it('should render all five calculators', async () => {
+        const component = await mount();
 
         const headings = component.renderRoot.querySelectorAll('h3');
-        expect(headings.length).toBe(3);
+        expect(headings.length).toBe(5);
         expect(headings[0].textContent).toContain('What is X% of Y?');
         expect(headings[1].textContent).toContain('X is what % of Y?');
         expect(headings[2].textContent).toContain('% Change from X to Y');
+        expect(headings[3].textContent).toContain('X is Y% of what?');
+        expect(headings[4].textContent).toContain('% Difference between X and Y');
     });
 
     it('should show dash when inputs are empty', async () => {
-        const component = window.document.createElement(componentTag) as LitElement;
-        document.body.appendChild(component);
-        await component.updateComplete;
+        const component = await mount();
 
-        const results = component.renderRoot.querySelectorAll('.text-2xl');
-        expect(results[0].textContent?.trim()).toBe('—');
-        expect(results[1].textContent?.trim()).toBe('—');
-        expect(results[2].textContent?.trim()).toBe('—');
+        for (let id = 1; id <= 5; id++) {
+            expect(result(component, id)).toBe('—');
+        }
     });
 
-    it('should have six independent input fields', async () => {
-        const component = window.document.createElement(componentTag) as LitElement;
-        document.body.appendChild(component);
-        await component.updateComplete;
+    it('should have ten independent input fields', async () => {
+        const component = await mount();
 
         const inputs = component.renderRoot.querySelectorAll('input');
-        expect(inputs.length).toBe(6);
+        expect(inputs.length).toBe(10);
     });
 
-    it('should calculate X% of Y correctly', async () => {
-        const component = window.document.createElement(componentTag) as PercentageCalculator;
-        document.body.appendChild(component);
-        await component.updateComplete;
+    it('should mark all result panels as live regions', async () => {
+        const component = await mount();
 
-        const inputs = component.renderRoot.querySelectorAll('input');
-        (inputs[0] as HTMLInputElement).value = '10';
-        inputs[0].dispatchEvent(new Event('input'));
-        (inputs[1] as HTMLInputElement).value = '200';
-        inputs[1].dispatchEvent(new Event('input'));
-        await component.updateComplete;
+        const liveRegions = component.renderRoot.querySelectorAll('[role="status"][aria-live="polite"]');
+        expect(liveRegions.length).toBe(5);
+    });
 
-        const results = component.renderRoot.querySelectorAll('.text-2xl');
-        expect(results[0].textContent?.trim()).toBe('20.00');
+    it('should calculate X% of Y correctly and trim trailing zeros', async () => {
+        const component = await mount();
+        await setInputs(component, { 0: '10', 1: '200' });
+
+        expect(result(component, 1)).toBe('20');
     });
 
     it('should calculate X is what % of Y correctly', async () => {
-        const component = window.document.createElement(componentTag) as PercentageCalculator;
-        document.body.appendChild(component);
-        await component.updateComplete;
+        const component = await mount();
+        await setInputs(component, { 2: '50', 3: '200' });
 
-        const inputs = component.renderRoot.querySelectorAll('input');
-        (inputs[2] as HTMLInputElement).value = '50';
-        inputs[2].dispatchEvent(new Event('input'));
-        (inputs[3] as HTMLInputElement).value = '200';
-        inputs[3].dispatchEvent(new Event('input'));
-        await component.updateComplete;
-
-        const results = component.renderRoot.querySelectorAll('.text-2xl');
-        expect(results[1].textContent?.trim()).toBe('25.00%');
+        expect(result(component, 2)).toBe('25%');
     });
 
-    it('should calculate % change correctly', async () => {
-        const component = window.document.createElement(componentTag) as PercentageCalculator;
-        document.body.appendChild(component);
-        await component.updateComplete;
+    it('should return dash for division by zero in "X is what % of Y"', async () => {
+        const component = await mount();
+        await setInputs(component, { 2: '50', 3: '0' });
 
-        const inputs = component.renderRoot.querySelectorAll('input');
-        (inputs[4] as HTMLInputElement).value = '100';
-        inputs[4].dispatchEvent(new Event('input'));
-        (inputs[5] as HTMLInputElement).value = '150';
-        inputs[5].dispatchEvent(new Event('input'));
-        await component.updateComplete;
+        expect(result(component, 2)).toBe('—');
+    });
 
-        const results = component.renderRoot.querySelectorAll('.text-2xl');
-        expect(results[2].textContent?.trim()).toBe('+50.00%');
+    it('should calculate positive % change with Increase label', async () => {
+        const component = await mount();
+        await setInputs(component, { 4: '100', 5: '150' });
+
+        expect(result(component, 3)).toBe('+50%');
+        expect(component.renderRoot.textContent).toContain('Increase');
+    });
+
+    it('should calculate negative % change with Decrease label', async () => {
+        const component = await mount();
+        await setInputs(component, { 4: '100', 5: '50' });
+
+        expect(result(component, 3)).toBe('-50%');
+        expect(component.renderRoot.textContent).toContain('Decrease');
+    });
+
+    it('should treat 0% change as neutral "No change"', async () => {
+        const component = await mount();
+        await setInputs(component, { 4: '100', 5: '100' });
+
+        expect(result(component, 3)).toBe('0%');
+        expect(component.renderRoot.textContent).toContain('No change');
+        expect(component.renderRoot.textContent).not.toContain('Increase');
+    });
+
+    it('should return dash when "from" value is zero for % change', async () => {
+        const component = await mount();
+        await setInputs(component, { 4: '0', 5: '100' });
+
+        expect(result(component, 3)).toBe('—');
+    });
+
+    it('should calculate "X is Y% of what?" (base recovery)', async () => {
+        const component = await mount();
+        await setInputs(component, { 6: '25', 7: '50' });
+
+        expect(result(component, 4)).toBe('50');
+    });
+
+    it('should return dash for zero percentage in base recovery', async () => {
+        const component = await mount();
+        await setInputs(component, { 6: '25', 7: '0' });
+
+        expect(result(component, 4)).toBe('—');
+    });
+
+    it('should calculate symmetric % difference', async () => {
+        const component = await mount();
+        await setInputs(component, { 8: '40', 9: '60' });
+
+        expect(result(component, 5)).toBe('40%');
+    });
+
+    it('should return dash when both values are zero for % difference', async () => {
+        const component = await mount();
+        await setInputs(component, { 8: '0', 9: '0' });
+
+        expect(result(component, 5)).toBe('—');
+    });
+
+    it('should ignore non-numeric input', async () => {
+        const component = await mount();
+        await setInputs(component, { 0: 'abc', 1: '200' });
+
+        expect(result(component, 1)).toBe('—');
     });
 
     afterEach(() => {

--- a/src/percentage-calculator/percentage-calculator.ts
+++ b/src/percentage-calculator/percentage-calculator.ts
@@ -81,7 +81,7 @@ const PANEL_META: Array<Omit<PanelConfig, 'result'>> = [
     {
         id: 5,
         title: '% Difference between X and Y',
-        formula: '|X − Y| ÷ ((X + Y) ÷ 2) × 100',
+        formula: '|X − Y| ÷ |(X + Y) ÷ 2| × 100',
         fields: [
             { label: 'Value X', placeholder: '40', key: 'c5A' },
             { label: 'Value Y', placeholder: '60', key: 'c5B' },
@@ -165,14 +165,18 @@ export class PercentageCalculator extends WebComponentBase {
             return EMPTY;
         }
 
-        const change = ((to - from) / from) * 100;
+        // Round first, then pick the tone/label from the value the user actually
+        // sees — otherwise a tiny change like 0.0000001% renders as "+0%" yet is
+        // still labelled "Increase".
+        const display = this.fmt(((to - from) / from) * 100);
+        const rounded = Number(display);
 
-        if (change > 0) {
-            return { text: `+${this.fmt(change)}%`, tone: 'positive', subtitle: 'Increase' };
+        if (rounded > 0) {
+            return { text: `+${display}%`, tone: 'positive', subtitle: 'Increase' };
         }
 
-        if (change < 0) {
-            return { text: `${this.fmt(change)}%`, tone: 'negative', subtitle: 'Decrease' };
+        if (rounded < 0) {
+            return { text: `${display}%`, tone: 'negative', subtitle: 'Decrease' };
         }
 
         return { text: '0%', tone: 'neutral', subtitle: 'No change' };

--- a/src/percentage-calculator/percentage-calculator.ts
+++ b/src/percentage-calculator/percentage-calculator.ts
@@ -2,190 +2,285 @@ import { html } from 'lit';
 import { WebComponentBase } from '../_web-component/WebComponentBase.js';
 import percentageCalculatorStyles from './percentage-calculator.css.js';
 import { customElement, state } from 'lit/decorators.js';
+import '../t-copy-button/t-copy-button.js';
+
+type Tone = 'neutral' | 'positive' | 'negative';
+
+type FieldKey =
+    | 'c1Percent' | 'c1Value'
+    | 'c2X' | 'c2Y'
+    | 'c3From' | 'c3To'
+    | 'c4X' | 'c4Percent'
+    | 'c5A' | 'c5B';
+
+interface PanelResult {
+    text: string;
+    tone: Tone;
+    subtitle?: string;
+}
+
+interface PanelField {
+    label: string;
+    placeholder: string;
+    key: FieldKey;
+}
+
+interface PanelConfig {
+    id: number;
+    title: string;
+    formula: string;
+    fields: PanelField[];
+    result: PanelResult;
+}
+
+const EMPTY: PanelResult = { text: '—', tone: 'neutral' };
+
+const TONE_BG: Record<Tone, string> = {
+    neutral: 'bg-gray-100 dark:bg-gray-700',
+    positive: 'bg-green-100 dark:bg-green-900/30',
+    negative: 'bg-red-100 dark:bg-red-900/30',
+};
+
+const PANEL_META: Array<Omit<PanelConfig, 'result'>> = [
+    {
+        id: 1,
+        title: 'What is X% of Y?',
+        formula: 'X ÷ 100 × Y',
+        fields: [
+            { label: 'Percentage (%)', placeholder: '10', key: 'c1Percent' },
+            { label: 'Of Value', placeholder: '200', key: 'c1Value' },
+        ],
+    },
+    {
+        id: 2,
+        title: 'X is what % of Y?',
+        formula: 'X ÷ Y × 100',
+        fields: [
+            { label: 'Value X', placeholder: '25', key: 'c2X' },
+            { label: 'Of Value Y', placeholder: '200', key: 'c2Y' },
+        ],
+    },
+    {
+        id: 3,
+        title: '% Change from X to Y',
+        formula: '(Y − X) ÷ X × 100',
+        fields: [
+            { label: 'From Value', placeholder: '80', key: 'c3From' },
+            { label: 'To Value', placeholder: '100', key: 'c3To' },
+        ],
+    },
+    {
+        id: 4,
+        title: 'X is Y% of what?',
+        formula: 'X ÷ (Y ÷ 100)',
+        fields: [
+            { label: 'Value X', placeholder: '25', key: 'c4X' },
+            { label: 'Percentage (%)', placeholder: '50', key: 'c4Percent' },
+        ],
+    },
+    {
+        id: 5,
+        title: '% Difference between X and Y',
+        formula: '|X − Y| ÷ ((X + Y) ÷ 2) × 100',
+        fields: [
+            { label: 'Value X', placeholder: '40', key: 'c5A' },
+            { label: 'Value Y', placeholder: '60', key: 'c5B' },
+        ],
+    },
+];
 
 @customElement('percentage-calculator')
 export class PercentageCalculator extends WebComponentBase {
     static override styles = [WebComponentBase.styles, percentageCalculatorStyles];
 
-    // Calculator 1: What is X% of Y?
+    // Calc 1: What is X% of Y?
     @state() private c1Percent = '';
     @state() private c1Value = '';
 
-    // Calculator 2: X is what % of Y?
+    // Calc 2: X is what % of Y?
     @state() private c2X = '';
     @state() private c2Y = '';
 
-    // Calculator 3: % change from X to Y
+    // Calc 3: % change from X to Y
     @state() private c3From = '';
     @state() private c3To = '';
 
-    private getResult1(): string {
-        const pct = parseFloat(this.c1Percent);
-        const val = parseFloat(this.c1Value);
+    // Calc 4: X is Y% of what?
+    @state() private c4X = '';
+    @state() private c4Percent = '';
 
-        if (isNaN(pct) || isNaN(val)) {
-            return '—';
-        }
+    // Calc 5: % difference between X and Y
+    @state() private c5A = '';
+    @state() private c5B = '';
 
-        return ((pct / 100) * val).toFixed(2);
-    }
-
-    private getResult2(): string {
-        const x = parseFloat(this.c2X);
-        const y = parseFloat(this.c2Y);
-
-        if (isNaN(x) || isNaN(y) || y === 0) {
-            return '—';
-        }
-
-        return `${((x / y) * 100).toFixed(2)}%`;
-    }
-
-    private getResult3(): { text: string; positive: boolean } | null {
-        const from = parseFloat(this.c3From);
-        const to = parseFloat(this.c3To);
-
-        if (isNaN(from) || isNaN(to) || from === 0) {
+    private parse(value: string): number | null {
+        if (value.trim() === '') {
             return null;
         }
 
+        const num = Number(value);
+
+        if (!Number.isFinite(num)) {
+            return null;
+        }
+
+        return num;
+    }
+
+    private fmt(n: number): string {
+        return String(Math.round(n * 1e6) / 1e6);
+    }
+
+    private setField(key: FieldKey, value: string) {
+        this[key] = value;
+    }
+
+    private getResult1(): PanelResult {
+        const pct = this.parse(this.c1Percent);
+        const val = this.parse(this.c1Value);
+
+        if (pct === null || val === null) {
+            return EMPTY;
+        }
+
+        return { text: this.fmt((pct / 100) * val), tone: 'neutral' };
+    }
+
+    private getResult2(): PanelResult {
+        const x = this.parse(this.c2X);
+        const y = this.parse(this.c2Y);
+
+        if (x === null || y === null || y === 0) {
+            return EMPTY;
+        }
+
+        return { text: `${this.fmt((x / y) * 100)}%`, tone: 'neutral' };
+    }
+
+    private getResult3(): PanelResult {
+        const from = this.parse(this.c3From);
+        const to = this.parse(this.c3To);
+
+        if (from === null || to === null || from === 0) {
+            return EMPTY;
+        }
+
         const change = ((to - from) / from) * 100;
-        return {
-            text: `${change >= 0 ? '+' : ''}${change.toFixed(2)}%`,
-            positive: change >= 0,
-        };
+
+        if (change > 0) {
+            return { text: `+${this.fmt(change)}%`, tone: 'positive', subtitle: 'Increase' };
+        }
+
+        if (change < 0) {
+            return { text: `${this.fmt(change)}%`, tone: 'negative', subtitle: 'Decrease' };
+        }
+
+        return { text: '0%', tone: 'neutral', subtitle: 'No change' };
     }
 
-    private renderCalculator1() {
+    private getResult4(): PanelResult {
+        const x = this.parse(this.c4X);
+        const pct = this.parse(this.c4Percent);
+
+        if (x === null || pct === null || pct === 0) {
+            return EMPTY;
+        }
+
+        return { text: this.fmt(x / (pct / 100)), tone: 'neutral' };
+    }
+
+    private getResult5(): PanelResult {
+        const a = this.parse(this.c5A);
+        const b = this.parse(this.c5B);
+
+        if (a === null || b === null) {
+            return EMPTY;
+        }
+
+        const average = (a + b) / 2;
+
+        if (average === 0) {
+            return EMPTY;
+        }
+
+        const diff = (Math.abs(a - b) / Math.abs(average)) * 100;
+        return { text: `${this.fmt(diff)}%`, tone: 'neutral' };
+    }
+
+    private get panels(): PanelConfig[] {
+        const results = [
+            this.getResult1(),
+            this.getResult2(),
+            this.getResult3(),
+            this.getResult4(),
+            this.getResult5(),
+        ];
+
+        return PANEL_META.map((meta, index) => ({ ...meta, result: results[index] }));
+    }
+
+    private renderField(field: PanelField) {
         return html`
-            <div class="p-4 bg-gray-50 dark:bg-gray-800 rounded">
-                <h3 class="font-bold mb-3">What is X% of Y?</h3>
-                <div class="grid grid-cols-2 gap-2">
-                    <label class="block">
-                        <span class="text-sm">Percentage (%)</span>
-                        <input
-                            class="form-input text-end"
-                            type="number"
-                            step="0.01"
-                            placeholder="10"
-                            .value=${this.c1Percent}
-                            @input=${(e: Event) => { this.c1Percent = (e.target as HTMLInputElement).value; }}
-                        />
-                    </label>
-                    <label class="block">
-                        <span class="text-sm">Of Value</span>
-                        <input
-                            class="form-input text-end"
-                            type="number"
-                            step="0.01"
-                            placeholder="200"
-                            .value=${this.c1Value}
-                            @input=${(e: Event) => { this.c1Value = (e.target as HTMLInputElement).value; }}
-                        />
-                    </label>
-                </div>
-                <div class="mt-3 p-3 bg-blue-100 dark:bg-blue-900/30 rounded text-center">
-                    <div class="text-sm text-gray-500">Result</div>
-                    <div class="text-2xl font-bold">${this.getResult1()}</div>
-                </div>
-            </div>
+            <label class="block">
+                <span class="text-sm">${field.label}</span>
+                <input
+                    class="form-input text-end"
+                    type="number"
+                    inputmode="decimal"
+                    step="0.01"
+                    placeholder=${field.placeholder}
+                    .value=${this[field.key]}
+                    @input=${(e: Event) =>
+                        this.setField(field.key, (e.target as HTMLInputElement).value)}
+                />
+            </label>
         `;
     }
 
-    private renderCalculator2() {
-        return html`
-            <div class="p-4 bg-gray-50 dark:bg-gray-800 rounded">
-                <h3 class="font-bold mb-3">X is what % of Y?</h3>
-                <div class="grid grid-cols-2 gap-2">
-                    <label class="block">
-                        <span class="text-sm">Value X</span>
-                        <input
-                            class="form-input text-end"
-                            type="number"
-                            step="0.01"
-                            placeholder="25"
-                            .value=${this.c2X}
-                            @input=${(e: Event) => { this.c2X = (e.target as HTMLInputElement).value; }}
-                        />
-                    </label>
-                    <label class="block">
-                        <span class="text-sm">Of Value Y</span>
-                        <input
-                            class="form-input text-end"
-                            type="number"
-                            step="0.01"
-                            placeholder="200"
-                            .value=${this.c2Y}
-                            @input=${(e: Event) => { this.c2Y = (e.target as HTMLInputElement).value; }}
-                        />
-                    </label>
-                </div>
-                <div class="mt-3 p-3 bg-green-100 dark:bg-green-900/30 rounded text-center">
-                    <div class="text-sm text-gray-500">Result</div>
-                    <div class="text-2xl font-bold">${this.getResult2()}</div>
-                </div>
-            </div>
-        `;
-    }
-
-    private renderCalculator3() {
-        const result = this.getResult3();
-        const bgClass = result === null
-            ? 'bg-gray-100 dark:bg-gray-700'
-            : result.positive
-                ? 'bg-green-100 dark:bg-green-900/30'
-                : 'bg-red-100 dark:bg-red-900/30';
+    private renderResult(id: number, result: PanelResult) {
+        const hasResult = result.text !== '—';
 
         return html`
-            <div class="p-4 bg-gray-50 dark:bg-gray-800 rounded">
-                <h3 class="font-bold mb-3">% Change from X to Y</h3>
-                <div class="grid grid-cols-2 gap-2">
-                    <label class="block">
-                        <span class="text-sm">From Value</span>
-                        <input
-                            class="form-input text-end"
-                            type="number"
-                            step="0.01"
-                            placeholder="80"
-                            .value=${this.c3From}
-                            @input=${(e: Event) => { this.c3From = (e.target as HTMLInputElement).value; }}
-                        />
-                    </label>
-                    <label class="block">
-                        <span class="text-sm">To Value</span>
-                        <input
-                            class="form-input text-end"
-                            type="number"
-                            step="0.01"
-                            placeholder="100"
-                            .value=${this.c3To}
-                            @input=${(e: Event) => { this.c3To = (e.target as HTMLInputElement).value; }}
-                        />
-                    </label>
-                </div>
-                <div class="mt-3 p-3 ${bgClass} rounded text-center">
-                    <div class="text-sm text-gray-500">Result</div>
-                    <div class="text-2xl font-bold">
-                        ${result ? result.text : '—'}
+            <div
+                class="mt-3 p-3 ${TONE_BG[result.tone]} rounded text-center"
+                role="status"
+                aria-live="polite"
+            >
+                <div class="text-sm text-gray-500 dark:text-gray-400">Result</div>
+                <div class="flex items-center justify-center gap-2">
+                    <div class="text-2xl font-bold break-all" data-testid="result-${id}">
+                        ${result.text}
                     </div>
-                    ${result
-                        ? html`<div class="text-xs text-gray-500">
-                              ${result.positive ? 'Increase' : 'Decrease'}
-                          </div>`
+                    ${hasResult
+                        ? html`<t-copy-button .text=${result.text}></t-copy-button>`
                         : ''}
                 </div>
+                ${result.subtitle
+                    ? html`<div class="text-xs text-gray-500 dark:text-gray-400">${result.subtitle}</div>`
+                    : ''}
+            </div>
+        `;
+    }
+
+    private renderPanel(config: PanelConfig) {
+        return html`
+            <div class="p-4 bg-gray-50 dark:bg-gray-800 rounded">
+                <h3 class="font-bold mb-1">${config.title}</h3>
+                <p class="text-xs text-gray-500 dark:text-gray-400 mb-3">${config.formula}</p>
+                <div class="grid grid-cols-2 gap-2">
+                    ${config.fields.map((field) => this.renderField(field))}
+                </div>
+                ${this.renderResult(config.id, config.result)}
             </div>
         `;
     }
 
     override render() {
         return html`
-            <div class="space-y-6">
-                ${this.renderCalculator1()}
-                ${this.renderCalculator2()}
-                ${this.renderCalculator3()}
+            <div class="space-y-6 text-gray-900 dark:text-gray-100">
+                ${this.panels.map((panel) => this.renderPanel(panel))}
 
-                <div class="text-xs text-gray-500">
+                <div class="text-xs text-gray-500 dark:text-gray-400">
                     <strong>Note:</strong> Each calculator operates independently.
                     Enter values and results update instantly.
                 </div>


### PR DESCRIPTION
## Summary

Fixes dark mode for these tools when consumed as Shadow-DOM web components, and improves the `percentage-calculator` tool.

### 1. Dark mode fix (repo-wide, `web-component` infra)

Consumers toggle dark mode with a `.dark` class on an ancestor (`<html>`/`<body>`/wrapper). That class can't cross the shadow boundary, and `@media (prefers-color-scheme)` can't see an app-level toggle. Two coupled changes make `dark:` utilities work:

- **`scripts/css-to-ts.js`** — map Tailwind's `dark:` variant to `:host(.dark)` via `@custom-variant dark (&:is(:host(.dark) *))`.
- **`src/_web-component/WebComponentBase.ts`** — mirror an ancestor `.dark` onto the component host (`closest('.dark')` + `MutationObserver` on `<html>`/`<body>` + `matchMedia` fallback), so `:host(.dark)` actually matches. Cleaned up on disconnect.

**Also fixes a latent, repo-wide bug:** the generated `.css.ts` embeds CSS inside a lit `` css`…` `` template literal. Tailwind emits escaped selectors like `.dark\:bg-gray-800`, but the template literal collapsed `\:` -> `:` at runtime, producing invalid selectors the browser silently dropped — breaking **every** `dark:` / `hover:` / `sm:` / fraction variant utility used directly in markup. `css-to-ts.js` now escapes backslashes (and backticks / `${`) before embedding.

> Note: `.css.ts` files are gitignored build artifacts (regenerated by `npm run css`), so only the generator + base class change here; every tool picks up the fix on build.

### 2. `percentage-calculator` improvements

- Add **"X is Y% of what?"** (base recovery) and symmetric **"% difference"** calculators (5 total).
- Fix `+0.00%` mislabeled as *Increase* -> neutral **"No change"**; stricter numeric parsing; trim trailing zeros.
- Per-result **copy buttons**, `role="status"`/`aria-live` regions, `inputmode="decimal"`, and self-contained dark text (`text-gray-900 dark:text-gray-100`).
- Refactor to a data-driven panel renderer; tests expanded to **18**.

## Verification

- Verified live in-browser: with a consumer `.dark` toggle (OS in light mode), the host mirrors `.dark` and panels render `gray-800` bg / `gray-100` text.
- **Full suite green: 490 tests / 166 suites.**

## Notes for reviewers

- This is a **repo-wide** correctness fix — every tool's inline variant utilities (`dark:`, `hover:`, responsive) now emit valid selectors, and all tools honor the consumer's `.dark` toggle (previously only OS-based media, and inline `dark:*` were dropped entirely).
